### PR TITLE
Updating Dockerfiles to remove warnings

### DIFF
--- a/Dockerfile-classic
+++ b/Dockerfile-classic
@@ -5,7 +5,7 @@
 
 FROM node:latest
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile-multi
+++ b/Dockerfile-multi
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/node:latest-dev as builder
+FROM cgr.dev/chainguard/node:latest-dev AS builder
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Adding a blurb on slim images to the Migration doc and testing things out, I ran into a few ugly warnings with the `docker build` commands. These changes should remove them.